### PR TITLE
fix: hide php version

### DIFF
--- a/laravel.ini
+++ b/laravel.ini
@@ -18,6 +18,8 @@ max_execution_time = 36000
 
 date.timezone = Australia/Melbourne
 
+expose_php = Off
+
 ; Opcache
 
 opcache.enable = 1

--- a/nginx/php-api.conf
+++ b/nginx/php-api.conf
@@ -12,6 +12,8 @@ http {
 
     include /etc/nginx/mime.types;
 
+    proxy_hide_header X-Powered-By;
+
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';

--- a/nginx/php-web.conf
+++ b/nginx/php-web.conf
@@ -11,6 +11,7 @@ events { worker_connections 1024; }
 http {
 
     proxy_headers_hash_bucket_size 64;
+    proxy_hide_header X-Powered-By;
 
     # buffering
     client_body_buffer_size 10K;


### PR DESCRIPTION
Turn off the expose_php ini directive to hide the `X-Powered-By` header from appearing.

Likewise add the proxy_hide_header directive to the nginx.conf files.