### PR TITLE
Change Server directive header name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,6 +115,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
     && install -m755 objs/ngx_http_image_filter_module-debug.so /usr/lib/nginx/modules/ngx_http_image_filter_module-debug.so \
     && install -m755 objs/ngx_http_geoip_module-debug.so /usr/lib/nginx/modules/ngx_http_geoip_module-debug.so \
     && install -m755 objs/ngx_stream_geoip_module-debug.so /usr/lib/nginx/modules/ngx_stream_geoip_module-debug.so \
+    && apk add nginx-mod-http-headers-more \
     && ln -s ../../usr/lib/nginx/modules /etc/nginx/modules \
     && strip /usr/sbin/nginx* \
     && strip /usr/lib/nginx/modules/*.so \

--- a/nginx/php-api.conf
+++ b/nginx/php-api.conf
@@ -1,3 +1,4 @@
+load_module "modules/ngx_http_headers_more_filter_module.so";
 user  nginx;
 worker_processes  1;
 
@@ -9,6 +10,8 @@ events {
 }
 
 http {
+
+    more_set_headers "Server: beamible.com";
 
     include /etc/nginx/mime.types;
 

--- a/nginx/php-web.conf
+++ b/nginx/php-web.conf
@@ -26,6 +26,8 @@ http {
     fastcgi_send_timeout 240s;
     fastcgi_read_timeout 240s;
 
+    server_tokens   off;
+
     # Gzip compression
     gzip             on;
     gzip_comp_level  6;

--- a/nginx/php-web.conf
+++ b/nginx/php-web.conf
@@ -1,3 +1,5 @@
+load_module "modules/ngx_http_headers_more_filter_module.so";
+
 user www-data;
 
 daemon off;
@@ -9,6 +11,7 @@ worker_processes auto;
 events { worker_connections 1024; }
 
 http {
+    more_set_headers "Server: beamible.com";
 
     proxy_headers_hash_bucket_size 64;
     proxy_hide_header X-Powered-By;


### PR DESCRIPTION
This PR sets server_tokens config to off at api-web.conf file and also adds a module to rename the server directive on headers from Server: nginx to Server: beamible.com

I was reading the nginx website and I found this doc [Nginx Headers More](https://www.nginx.com/resources/wiki/modules/headers_more/ )

Module installed: `nginx-mod-http-headers-more` that is available at [Alpine Linux Repositories](https://pkgs.alpinelinux.org/package/edge/main/x86/nginx-mod-http-headers-more)

![nginx](https://user-images.githubusercontent.com/3869640/115536982-b13d7880-a2dd-11eb-980c-fea9913821ed.png)


